### PR TITLE
[fix/#35] fix: nginx 라우팅 및 ssl 핸드셰이킹 로직 변경

### DIFF
--- a/nginx/templates/nginx.conf.template
+++ b/nginx/templates/nginx.conf.template
@@ -7,9 +7,28 @@ events {
     worker_connections 1024;
 }
 
-http {
+stream {
+    map $remote_addr$proxy_protocol_addr$server_port$ssl_preread_server_name $backend {
+        # HTTP 트래픽 (80 포트)
+        ~^.*80bows\.co\.kr$ 127.0.0.1:8081;
+        ~^.*80 127.0.0.1:8082;
+
+        # HTTPS 트래픽 (443 포트)
+        ~^.*443bows\.co\.kr$ 127.0.0.1:8443;
+        ~^.*443 ${INGRESS_CONTROLLER_EXTERNAL_IP}:443;
+    }
+
     server {
         listen 80;
+        listen 443;
+        ssl_preread on;
+        proxy_pass $backend;
+    }
+}
+
+http {
+    server {
+        listen 127.0.0.1:8081;
         server_name bows.co.kr;
 
         location /.well-known/acme-challenge/ {
@@ -23,8 +42,8 @@ http {
     }
 
     server {
-        listen 80;
-        server_name ~^(?!bows\.co\.kr).*$;
+        listen 127.0.0.1:8082;
+        server_name _;
 
         location /.well-known/acme-challenge/ {
             proxy_pass http://${INGRESS_CONTROLLER_EXTERNAL_IP};
@@ -40,7 +59,7 @@ http {
     }
 
     server {
-        listen 443 ssl;
+        listen 127.0.0.1:8443 ssl;
         server_name bows.co.kr;
         server_tokens off;
 
@@ -61,26 +80,4 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
     }
-
-    server {
-        listen 443;
-        server_name ~^(?!bows\.co\.kr).*$;
-        server_tokens off;
-
-        location / {
-            proxy_pass https://${INGRESS_CONTROLLER_EXTERNAL_IP};
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_ssl_server_name on;
-            proxy_intercept_errors on;
-            error_page 404 = @handle_404;
-        }
-
-        location @handle_404 {
-            return 404 "The requested resource could not be found.";
-        }
-    }
-
 }


### PR DESCRIPTION
- https request 그대로를 뒷단의 traefik으로 넘기기 위해 http블록(애플리케이션 레이어 부하분산)이 아닌 stream블록(transport 레이어 부하분산) 이용
- ssl_preread로 ssl 핸드셰이크를 완전히 처리하지 않고도 SNI를 알아내서 그에 맞게 라우팅 로직을 태우기

- 이때 기존에 있던 ingress route 라우팅에 사용했던 server block은 삭제
  - server block내에서 `proxy_pass https://`를 사용할 경우 Nginx가 참고할 수 있는 인증서를 바탕으로(이번의 경우 'bows.co.kr'에 대한 인증서) 프록시하려는 서버와 새로운 ssl/tls 연결을 설정하기 때문
  - 따라서 별도이 server 블록은 설정하지 않고, 받은 https 패킷 그대로 보내는 SSL Passthrough를 사용

close #35 